### PR TITLE
Fix links pointing to draft js

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ An editor component accepting plugins. [see source](https://github.com/draft-js-
 
 | Props                                                           |                                         Description                                          | Required |
 | --------------------------------------------------------------- | :------------------------------------------------------------------------------------------: | -------: |
-| editorState                                                     | [see here](https://facebook.github.io/draft-js/docs/api-reference-editor-state.html#content) |       \* |
-| onChange                                                        |   [see here](https://facebook.github.io/draft-js/docs/api-reference-editor.html#onchange)    |       \* |
+| editorState                                                     | [see here](https://facebook.github.io/draft-js/docs/api-reference-editor-state#content) |       \* |
+| onChange                                                        |   [see here](https://draftjs.org/docs/api-reference-editor/#onchange)    |       \* |
 | plugins                                                         |                                     an array of plugins                                      |          |
 | decorators                                                      |                                an array of custom decorators                                 |          |
 | defaultKeyBindings                                              |                                             bool                                             |          |
 | defaultBlockRenderMap                                           |                                             bool                                             |          |
-| all other props accepted by the DraftJS Editor except decorator |     [see here](https://facebook.github.io/draft-js/docs/api-reference-editor.html#props)     |          |
+| all other props accepted by the DraftJS Editor except decorator |     [see here](https://draftjs.org/docs/api-reference-editor/#props)     |          |
 
 Usage:
 


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

The links pointing to https://draftjs.org/ docs  were breaking. I fixed that

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
